### PR TITLE
Multi-channel support and also diceroll plugin

### DIFF
--- a/cmd/gobot/gobot.go
+++ b/cmd/gobot/gobot.go
@@ -31,7 +31,7 @@ func main() {
 	flag.StringVar(&pass, "pass", "", "Password for XMPP server")
 	flag.StringVar(&room, "room", "", "Room to join (i.e.: #myroom@hostname.com")
 	flag.StringVar(&name, "name", "gobot", "Name of the bot")
-	flag.StringVar(&logfile, "logfile", "/tmp/chatlog", "Name of the bot")
+	flag.StringVar(&logfile, "logfile", "/tmp/chatlog", "Path to log file")
 	flag.Var(&crons, "job", "List of jobs")
 	flag.Parse()
 

--- a/cmd/gobot/gobot.go
+++ b/cmd/gobot/gobot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gabeguz/gobot/plugins/beer"
 	"github.com/gabeguz/gobot/plugins/chatlog"
 	"github.com/gabeguz/gobot/plugins/cron"
+	"github.com/gabeguz/gobot/plugins/dice"
 	"github.com/gabeguz/gobot/plugins/dm"
 	"github.com/gabeguz/gobot/plugins/echo"
 	"github.com/gabeguz/gobot/plugins/jira"
@@ -23,17 +24,19 @@ import (
 )
 
 func main() {
-	var host, user, pass, room, name string
+	var host, user, pass, room, name, logfile string
 	var crons strslice
 	flag.StringVar(&host, "host", "", "Hostname:port of the XMPP server")
 	flag.StringVar(&user, "user", "", "Username of XMPP server (i.e.: foo@hostname.com")
 	flag.StringVar(&pass, "pass", "", "Password for XMPP server")
 	flag.StringVar(&room, "room", "", "Room to join (i.e.: #myroom@hostname.com")
 	flag.StringVar(&name, "name", "gobot", "Name of the bot")
+	flag.StringVar(&logfile, "logfile", "/tmp/chatlog", "Name of the bot")
 	flag.Var(&crons, "job", "List of jobs")
 	flag.Parse()
 
 	//TODO:Add some validation...but whatever for now
+	chatlog := chatlog.ChatLog{Filename: logfile}
 
 	bot := gb.Gobot{
 		slack.New(pass, room, name),
@@ -42,15 +45,15 @@ func main() {
 			beer.Beer{},
 			quote.Quote{},
 			dm.DirectMessage{},
+			dice.Dice{Log: chatlog},
+			chatlog,
 			stathat.StatHat{},
-			chatlog.ChatLog{},
 			troll.Troll{},
 			rickroll.RickRoll{},
 			url.Url{},
 			jira.Jira{},
 		},
 	}
-
 	/*
 		bot := gb.Gobot{
 			xmpp.New(host, user, pass, room, name),

--- a/gobot.go
+++ b/gobot.go
@@ -9,6 +9,7 @@ type Bot interface {
 	Name() string
 	FullName() string
 	Send(msg string)
+	Reply(orig Message, msg string)
 	Connect() error
 	PingServer(time.Duration)
 	Listen() chan Message
@@ -20,6 +21,7 @@ type Bot interface {
 type Message interface {
 	Body() string
 	From() string
+	Room() string
 }
 
 type Plugin interface {

--- a/plugins/beer/beer.go
+++ b/plugins/beer/beer.go
@@ -1,10 +1,11 @@
 package beer
 
 import (
-	"github.com/gabeguz/gobot"
 	"math/rand"
 	"strings"
 	"time"
+
+	"github.com/gabeguz/gobot"
 )
 
 var ayes = []string{
@@ -38,11 +39,11 @@ func (p Beer) Execute(msg gobot.Message, bot gobot.Bot) error {
 
 	now := time.Now()
 	if strings.HasPrefix(msg.Body(), "beer?") {
-		bot.Send(beer(now))
+		bot.Reply(msg, beer(now))
 	} else if strings.HasPrefix(msg.Body(), "ビール?") {
-		bot.Send(beer(now))
+		bot.Reply(msg, beer(now))
 	} else if strings.HasPrefix(msg.Body(), "맥주?") {
-		bot.Send(beer(now))
+		bot.Reply(msg, beer(now))
 	}
 
 	return nil

--- a/plugins/chatlog/chatlog.go
+++ b/plugins/chatlog/chatlog.go
@@ -7,36 +7,75 @@
 package chatlog
 
 import (
-	"github.com/gabeguz/gobot"
+	"fmt"
 	"log"
 	"os"
+
+	"github.com/gabeguz/gobot"
+	gb "github.com/gabeguz/gobot/bots/gobot"
+	sb "github.com/gabeguz/gobot/bots/slack"
+	xmpp "github.com/gabeguz/gobot/bots/xmpp"
 )
 
 // Helper struct that will implement the Helper interface
 type ChatLog struct {
+	Filename string
 }
 
 func (c ChatLog) Name() string {
 	return "Chatlog v1.0"
 }
 
+var users = map[string]string{}
+
 // Send allows the bot to send a message to this helper
 func (c ChatLog) Execute(message gobot.Message, bot gobot.Bot) error {
-	f := getLogFileHandle("/tmp/chatlog")
-	logit(message.Body(), f)
+	if c.Filename == "" {
+		c.Filename = "/tmp/chatlog"
+	}
+	b2 := bot.(gb.Gobot)
+	switch b3 := b2.InternalBot().(type) {
+	case *sb.Bot:
+		tmpmsg := message.(sb.Message)
+		mess := tmpmsg.EffectiveMessage()
+		if mess.Channel != b3.Opt.Room {
+			return nil
+		}
+		var n string
+		if user, ok := users[mess.User]; ok {
+			n = user
+		} else {
+			u, err := b3.Client().GetUserInfo(mess.User)
+			if err == nil {
+				n = u.Name
+				users[mess.User] = n
+			}
+		}
+		c.Logit(n, message.Body())
+		for _, a := range mess.Attachments {
+			c.Logit(message.From(), a.Title)
+			c.Logit(message.From(), a.Text)
+		}
+	case *xmpp.Bot:
+		if message.From() != b3.Opt.Room {
+			return nil
+		}
+		c.Logit(message.From(), message.Body())
+	default:
+		c.Logit(message.From(), message.Body())
+	}
 	return nil
 }
 
-func getLogFileHandle(path string) (f *os.File) {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+func (c ChatLog) Logit(author, message string) {
+	f, err := os.OpenFile(c.Filename, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		log.Fatalf("error opening file: %v", err)
 	}
-	return f
-}
-
-func logit(message string, f *os.File) {
-	log.SetOutput(f)
-	log.Println(message)
 	defer f.Close()
+	if message == "" {
+		return
+	}
+	log.SetOutput(f)
+	log.Println(fmt.Sprintf("%s: %s", author, message))
 }

--- a/plugins/dice/dice.go
+++ b/plugins/dice/dice.go
@@ -1,0 +1,96 @@
+package dice
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"math/rand"
+	"time"
+
+	"github.com/gabeguz/gobot"
+	gb "github.com/gabeguz/gobot/bots/gobot"
+	sb "github.com/gabeguz/gobot/bots/slack"
+	"github.com/gabeguz/gobot/plugins/chatlog"
+	"github.com/nlopes/slack"
+)
+
+type Dice struct {
+	Filename string
+	Log      chatlog.ChatLog
+}
+
+var diceRE = regexp.MustCompile(`^roll ([0-9]{1,3})d([0-9]{1,3}) ?([+-][0-9]+)?`)
+
+func (Dice) Name() string {
+	return "Dice v1.0"
+}
+
+var users = map[string]string{}
+
+func (d Dice) Execute(msg gobot.Message, bot gobot.Bot) error {
+	b2 := bot.(gb.Gobot)
+	if msg.From() != bot.FullName() {
+		if matches := diceRE.FindAllStringSubmatch(msg.Body(), -1); len(matches) > 0 {
+			rand.Seed(time.Now().UnixNano())
+			var rollresult = []int{}
+			dice, _ := strconv.Atoi(matches[0][2])
+			total := 0
+			bonus := 0
+			if len(matches[0]) > 2 {
+				bonus, _ = strconv.Atoi(strings.TrimSpace(matches[0][3]))
+			}
+			for i, _ := strconv.Atoi(matches[0][1]); i > 0; i -= 1 {
+				number := rand.Intn(dice) + 1
+				total += number
+				rollresult = append(rollresult, number)
+			}
+			switch b3 := b2.InternalBot().(type) {
+			case *sb.Bot:
+				tmpmsg := msg.(sb.Message)
+				mess := tmpmsg.EffectiveMessage()
+
+				c := b3.Client()
+				p := slack.NewPostMessageParameters()
+				p.EscapeText = false
+				p.Username = b3.Opt.Name
+				var n string
+				if user, ok := users[mess.User]; ok {
+					n = user
+				} else {
+					u, err := b3.Client().GetUserInfo(mess.User)
+					if err == nil {
+						n = u.Name
+						users[mess.User] = n
+					}
+				}
+				result := ""
+				if bonus == 0 {
+					result = fmt.Sprintf("%s rolls %sd%s for a total of %d", n, matches[0][1], matches[0][2], total)
+				} else {
+					result = fmt.Sprintf("%s rolls %sd%s for a total of %d (%s) = %d", n, matches[0][1], matches[0][2], total, matches[0][3], total+bonus)
+				}
+				d.Log.Logit(n, result)
+				p.Attachments = []slack.Attachment{
+					slack.Attachment{
+						Title: result,
+						Text:  fmt.Sprint(rollresult, matches[0][3]),
+					},
+				}
+
+				if mess.ThreadTimestamp != "" {
+					p.ThreadTimestamp = mess.ThreadTimestamp
+				}
+				c.PostMessage(mess.Channel, "", p)
+			default:
+				b := bytes.NewBuffer(nil)
+				fmt.Fprintln(b, fmt.Sprintf("%s rolls %sd%s: %v", msg.From(), matches[0][1], matches[0][2], rollresult))
+				d.Log.Logit(msg.From(), b.String())
+				bot.Send(b.String())
+			}
+		}
+	}
+	return nil
+}

--- a/plugins/dm/dm.go
+++ b/plugins/dm/dm.go
@@ -8,8 +8,9 @@
 package dm
 
 import (
-	"github.com/gabeguz/gobot"
 	"strings"
+
+	"github.com/gabeguz/gobot"
 )
 
 // Helper struct that will implement the helper interface
@@ -24,7 +25,7 @@ func (p DirectMessage) Name() string {
 func (p DirectMessage) Execute(message gobot.Message, cb gobot.Bot) error {
 	reply := dm(message.Body(), cb.Name())
 	if len(reply) > 0 {
-		cb.Send(reply)
+		cb.Reply(message, reply)
 	}
 	return nil
 }

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -32,7 +32,7 @@ func (p Jira) Execute(msg gobot.Message, bot gobot.Bot) error {
 		if len(matches) > 0 {
 			issues, err := jkl.List(fmt.Sprintf("key in (%s)", strings.Join(matches, ",")))
 			if err != nil {
-				bot.Send(fmt.Sprintf("I AM ERROR: %s", err.Error()))
+				bot.Reply(msg, fmt.Sprintf("I AM ERROR: %s", err.Error()))
 			}
 
 			switch b3 := b2.InternalBot().(type) {
@@ -42,7 +42,7 @@ func (p Jira) Execute(msg gobot.Message, bot gobot.Bot) error {
 				p.EscapeText = false
 				p.Username = b3.Opt.Name
 				p.Attachments = make([]slack.Attachment, 0, len(issues))
-				for _, issue := range issues {
+				for issue := range issues {
 					a := slack.Attachment{
 						Title:      fmt.Sprintf("%s : %s", issue.Key, issue.Fields.Summary),
 						TitleLink:  issue.URL(),
@@ -55,13 +55,13 @@ func (p Jira) Execute(msg gobot.Message, bot gobot.Bot) error {
 					p.Attachments = append(p.Attachments, a)
 				}
 
-				c.PostMessage(b3.Opt.Room, "", p)
+				c.PostMessage(msg.Room(), "", p)
 			default:
 				b := bytes.NewBuffer(nil)
-				for _, issue := range issues {
+				for issue := range issues {
 					fmt.Fprintln(b, fmt.Sprintf("%s|%s : %s", issue.URL(), issue.Key, issue.Fields.Summary))
 				}
-				bot.Send(b.String())
+				bot.Reply(msg, b.String())
 			}
 		}
 	}

--- a/plugins/quote/quote.go
+++ b/plugins/quote/quote.go
@@ -7,10 +7,11 @@
 package quote
 
 import (
-	"github.com/gabeguz/gobot"
 	"math/rand"
 	"strings"
 	"time"
+
+	"github.com/gabeguz/gobot"
 )
 
 // Helper will implement the Helper interface
@@ -34,7 +35,7 @@ func (p Quote) Execute(message gobot.Message, bot gobot.Bot) error {
 		q = quote("admin")
 	}
 	if len(q) > 0 {
-		bot.Send(q)
+		bot.Reply(message, q)
 	}
 	return nil
 }

--- a/plugins/rickroll/rickroll.go
+++ b/plugins/rickroll/rickroll.go
@@ -1,8 +1,9 @@
 package rickroll
 
 import (
-	"github.com/gabeguz/gobot"
 	"time"
+
+	"github.com/gabeguz/gobot"
 )
 
 var rickroll = []string{
@@ -26,7 +27,7 @@ func (p RickRoll) Execute(msg gobot.Message, bot gobot.Bot) error {
 	if msg.Body() == bot.Name()+": how are you feeling?" {
 		time.Sleep(5 * time.Second)
 		for _, s := range rickroll {
-			bot.Send(s)
+			bot.Reply(msg, s)
 			time.Sleep(3 * time.Second)
 		}
 	}

--- a/plugins/troll/troll.go
+++ b/plugins/troll/troll.go
@@ -1,8 +1,9 @@
 package troll
 
 import (
-	"github.com/gabeguz/gobot"
 	"strings"
+
+	"github.com/gabeguz/gobot"
 )
 
 const (
@@ -33,7 +34,7 @@ func (p Troll) Name() string {
 
 func (p Troll) Execute(msg gobot.Message, bot gobot.Bot) error {
 	if strings.HasPrefix(msg.Body(), "troll") {
-		bot.Send(troll)
+		bot.Reply(msg, troll)
 	}
 	return nil
 }

--- a/plugins/url/url.go
+++ b/plugins/url/url.go
@@ -2,9 +2,10 @@ package url
 
 import (
 	"fmt"
+	"net/url"
+
 	"github.com/gabeguz/gobot"
 	"github.com/thatguystone/swan"
-	"net/url"
 )
 
 type Url struct{}
@@ -31,7 +32,7 @@ func (p Url) Execute(msg gobot.Message, bot gobot.Bot) error {
 
 	// Respond with the article title
 	fmt.Printf("Title: %v\n", a)
-	bot.Send(a.Meta.Title)
+	bot.Reply(msg, a.Meta.Title)
 
 	return nil
 }


### PR DESCRIPTION
Kind of.

This allows a few things to be made channel-aware; Gobot will now respond to a
few commands directly in the channel where they are invoked. This includes the
brand-new dice-roll plugin, the jira plugin, the quote plugin.

Chatlog currently can only follow one channel; also the log usage is not thread-
safe. Chatlog should use a logger instance per plugin, and there should be a
plugin instance per monitored channel. This begins to look like we will need a
config file, maybe.