### PR TITLE
Use real name for dice rolls.

### DIFF
--- a/plugins/dice/dice.go
+++ b/plugins/dice/dice.go
@@ -62,7 +62,6 @@ func (d Dice) Execute(msg gobot.Message, bot gobot.Bot) error {
 				} else {
 					u, err := b3.Client().GetUserInfo(mess.User)
 					if err == nil {
-
 						n = u.RealName
 						users[mess.User] = n
 					}

--- a/plugins/dice/dice.go
+++ b/plugins/dice/dice.go
@@ -62,7 +62,8 @@ func (d Dice) Execute(msg gobot.Message, bot gobot.Bot) error {
 				} else {
 					u, err := b3.Client().GetUserInfo(mess.User)
 					if err == nil {
-						n = u.Name
+
+						n = u.RealName
 						users[mess.User] = n
 					}
 				}


### PR DESCRIPTION
This prevents a weird edge case that I hate.